### PR TITLE
Changed the suffix of the interface files to .cfg

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,8 @@
 - name: configurations
   template:
     src: device.j2
-    dest: "{{ network_interface_path }}/device-{{ item.device }}-{{ item.family | default('inet') }}"
+    dest: "{{ network_interface_path }}/device-{{ item.device }}-{{ item.family | default('inet') }}.cfg"
+    backup: yes
   with_items: network_interfaces
   register: network_configuration_result
 

--- a/templates/all_interfaces.j2
+++ b/templates/all_interfaces.j2
@@ -2,4 +2,4 @@
 auto lo
 iface lo inet loopback
 
-source {{ network_interface_path }}/*
+source {{ network_interface_path }}/*.cfg


### PR DESCRIPTION
Heya.. another potential feature to consider..

I've renamed the interface files that get loaded to be suffixed with .cfg
(this is currently live in my production also)
# good
- we can use `backup=yes` when we make changes.. (which I have put in)
  This means an admin can recover the previous config should things go wrong
# bad
- personally I like to (ad-hoc) `cat /etc/network/interfaces.d/*` and see the existing state in one command..
- people using an older version of the role should consider purging the old files
