### PR TITLE
Ensure bridge-utils package is installed.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,7 @@
   with_items:
   - vlan
   - ifenslave
+  - bridge-utils
 
 - include: all_interfaces.yml
   when: network_interfaces


### PR DESCRIPTION
Without bridge-utils installed, any bridge creation will fail.

closes #32
