### PR TITLE
Check mode breaks because path and dest undefined

### DIFF
--- a/tasks/manage_devices.yml
+++ b/tasks/manage_devices.yml
@@ -5,11 +5,12 @@
   register: network_existing_files
 
 # depending on change the result stores dest or path
+# check mode doesn't store any of those so use module args
 - name: configured files
   set_fact:
     network_configured_files: >-
       [{% for item in network_configuration_result.results | default([]) -%}
-        u"{{ item.dest | default(item.path) }}"
+        u"{{ item.dest | default(item.path) | default(item.invocation.module_args.dest) }}"
         {{ '' if loop.last else ',' }}
       {%- endfor %}]
 


### PR DESCRIPTION
Hey, firstly thanks for putting this module together its been really helpful in getting our own module in working order. I noticed that this thing breaks when you run it in check mode. I looked at the template module and annoyingly it returns something different depending on how its run and the change set. It seems like running the template module in check mode doesn't return path or dest? I tested with something silly like this:

```
- template:
    dest: /tmp/test
    src: test.j2
  register: test

- debug: var=test
```

When I run it in check mode I get:

```
{
    "test": {
        "changed": true, 
        "diff": {
            "after": "", 
            "after_header": "dynamically generated", 
            "before": ""
        }
    }
}
```

and when I run it without check I get:

```
{
    "test": {
        "changed": true, 
        "checksum": "da39a3ee5e6b4b0d3255bfef95601890afd80709", 
        "dest": "/tmp/test", 
        "diff": {
            "after": "", 
            "after_header": "dynamically generated", 
            "before": ""
        }, 
        "gid": 0, 
        "group": "root", 
        "md5sum": "d41d8cd98f00b204e9800998ecf8427e", 
        "mode": "0644", 
        "owner": "root", 
        "size": 0, 
        "src": "/home/ubuntu/.ansible/tmp/ansible-tmp-1471991735.19-268768173190611/source", 
        "state": "file", 
        "uid": 0
    }
}
```

or

```
{
    "test": {
        "changed": false, 
        "diff": {
            "after": {
                "path": "/tmp/test"
            }, 
            "before": {
                "path": "/tmp/test"
            }
        }, 
        "gid": 0, 
        "group": "root", 
        "mode": "0644", 
        "owner": "root", 
        "path": "/tmp/test", 
        "size": 0, 
        "state": "file", 
        "uid": 0
    }
}
```

luckily when you run run it `with_items` each of the items will have a invocation section like:

```
...
"invocation": {
                    "module_args": {
                        "dest": "/tmp/test", 
                        "src": "test.j2"
                    }, 
                    "module_name": "template"
                }, 
...
```

Since we will always be using template maybe we can just grab this out all the time? Or just in the case that path and dest aren't defined? Im not sure what you want to do here but it would be cool to have this able to run through a check.

Anyway possible I missed something in there but just thought I would bring this up since Im not sure if anyone else was seeing this issue.

Thanks again.
