### PR TITLE
Add option to order device startup in ifup

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,9 @@
 - name: configurations
   template:
     src: device.j2
-    dest: "{{ network_interface_path }}/device-{{ item.0 }}"
+    dest: "{{ network_interface_path }}/device-{{ item.1 | default([])
+            | rejectattr('order', 'undefined') | map(attribute='order')
+            | list | default([99], true) | min }}_{{ item.0 }}"
     mode: "{{ network_interface_permissions }}"
   with_items:
   - "{{ network_interfaces | default([]) | groupby('device') }}"

--- a/vars/debian-10.yml
+++ b/vars/debian-10.yml
@@ -1,0 +1,6 @@
+---
+network_service: "networking.service"
+
+# Don't use the service restart for individual interfaces as
+# `systemctl restart networking.service` does not take INTERFACE args
+network_restart_method: "interface"

--- a/vars/debian-9.yml
+++ b/vars/debian-9.yml
@@ -1,0 +1,6 @@
+---
+network_service: "networking.service"
+
+# Don't use the service restart for individual interfaces as
+# `systemctl restart networking.service` does not take INTERFACE args
+network_restart_method: "interface"


### PR DESCRIPTION
This allows to safely configure bonds, VLAN and bridges on top without having to fiddle with names.
This can be done by specifying `order` in any device stanza which will then evaluate to the 
smallest `order` set in any stanza for that device. Parameter `order` will evaluate to `99` if it is not set
for that device. 

The resulting files are then named `device-$order_$devicename`.

Would be great to have that functionality upstream.

On top this adds a default vars/ file for debian-9, which is of course optional.