### PR TITLE
Removed update_cache routine for offline use

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,25 +1,4 @@
 ---
-
-- name: Gather variables for each operating system
-  include_vars: "{{ item }}"
-  with_first_found:
-  - "{{ ansible_distribution | lower }}-{{ ansible_distribution_version | lower }}.yml"
-  - "{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
-  - "{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
-  - "{{ ansible_distribution | lower }}.yml"
-  - "{{ ansible_os_family | lower }}.yml"
-  tags:
-  - always
-
-- name: ensure basic networking tools are installed
-  apt:
-    pkg: "{{ item }}"
-    state: present
-    update_cache: yes
-    cache_valid_time: 86400
-  when: network_interfaces
-  with_items: "{{ network_interface_required_packages }}"
-
 - include: all_interfaces.yml
   when: network_interfaces
 


### PR DESCRIPTION
Removed the upate_cache reoutine from the tasks/main.yml so it will create an network interface even in offline use.